### PR TITLE
Force eager evaluation of task division

### DIFF
--- a/Server/Services/ProblemPluginFacade/ProblemPluginFacade.cs
+++ b/Server/Services/ProblemPluginFacade/ProblemPluginFacade.cs
@@ -77,7 +77,7 @@ namespace Server.Services
         {
             try
             {
-                return _problemPluginInstance.DivideTask(task);
+                return _problemPluginInstance.DivideTask(task).ToList();
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
Due to lazy evaluation of `IEnumerable` exceptions were thrown in unexpected methods and `TaskDivisionException` was not reported.