### PR TITLE
Hide binary fields in JSON responses

### DIFF
--- a/Server/Models/DistributedTask.cs
+++ b/Server/Models/DistributedTask.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using JsonApiDotNetCore.Models;
+using Newtonsoft.Json;
 
 namespace Server.Models
 {
@@ -28,11 +29,13 @@ namespace Server.Models
         public virtual DistributedTaskDefinition DistributedTaskDefinition { get; set; }
 
         [Required]
+        [JsonIgnore]
         public byte[] InputData { get; set; }
 
         [Attr("status", isImmutable: true)]
         public DistributedTaskStatus Status { get; set; } = DistributedTaskStatus.InProgress;
 
+        [JsonIgnore]
         public byte[] Result { get; set; }
 
         [HasMany("subtasks")]

--- a/Server/Models/Subtask.cs
+++ b/Server/Models/Subtask.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using JsonApiDotNetCore.Models;
+using Newtonsoft.Json;
 
 namespace Server.Models
 {
@@ -17,8 +18,10 @@ namespace Server.Models
         public DistributedTask DistributedTask { get; set; }
 
         [Required]
+        [JsonIgnore]
         public byte[] InputData { get; set; }
 
+        [JsonIgnore]
         public byte[] Result { get; set; }
 
         [Required]

--- a/Server/Models/SubtaskInProgress.cs
+++ b/Server/Models/SubtaskInProgress.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 using JsonApiDotNetCore.Models;
+using Newtonsoft.Json;
 
 namespace Server.Models
 {
@@ -25,6 +26,7 @@ namespace Server.Models
         [Attr("status", isImmutable: true)]
         public SubtaskStatus Status { get; set; } = SubtaskStatus.Executing;
 
+        [JsonIgnore]
         public byte[] Result { get; set; }
 
         // TODO: verify that string[] is the correct type here


### PR DESCRIPTION
`InputData` and `Result` are now not serialized when displaying an entity.