### PR TITLE
Set fixed row height

### DIFF
--- a/frontend/src/components/data-table/styled-data-table/overrides.css
+++ b/frontend/src/components/data-table/styled-data-table/overrides.css
@@ -4,5 +4,5 @@
 
 .ReactTable .rt-tr {
   align-items: center;
-  height: 2.5rem;
+  height: 2.75rem;
 }

--- a/frontend/src/features/distributed-nodes/table/table.tsx
+++ b/frontend/src/features/distributed-nodes/table/table.tsx
@@ -112,7 +112,7 @@ export class PureDistributedNodesTable extends Component<
           totalRecordsCount={totalRecordsCount}
           onFetchData={this.fetchData}
           initialPage={1}
-          initialPageSize={20}
+          initialPageSize={10}
           getForceFetchData={this.getFetchDataCallback}
         />
       </DataTableView>

--- a/frontend/src/features/distributed-task-definitions/table/table.tsx
+++ b/frontend/src/features/distributed-task-definitions/table/table.tsx
@@ -140,7 +140,7 @@ export class PureDistributedTaskDefinitionsTable extends Component<
           totalRecordsCount={totalRecordsCount}
           onFetchData={this.fetchData}
           initialPage={1}
-          initialPageSize={20}
+          initialPageSize={10}
           getForceFetchData={this.getFetchDataCallback}
         />
       </DataTableView>

--- a/frontend/src/features/distributed-tasks/table/table.tsx
+++ b/frontend/src/features/distributed-tasks/table/table.tsx
@@ -173,7 +173,7 @@ export class PureDistributedTasksTable extends Component<
           totalRecordsCount={totalRecordsCount}
           onFetchData={this.fetchData}
           initialPage={1}
-          initialPageSize={20}
+          initialPageSize={10}
           getForceFetchData={this.getFetchDataCallback}
         />
       </DataTableView>

--- a/frontend/src/features/subtasks/table/table.tsx
+++ b/frontend/src/features/subtasks/table/table.tsx
@@ -85,7 +85,7 @@ export class PureSubtasksTable extends Component<
           totalRecordsCount={totalRecordsCount}
           onFetchData={this.fetchData}
           initialPage={1}
-          initialPageSize={20}
+          initialPageSize={10}
           getForceFetchData={this.getFetchDataCallback}
         />
       </DataTableView>

--- a/frontend/src/utils/table/get-entities.ts
+++ b/frontend/src/utils/table/get-entities.ts
@@ -12,7 +12,7 @@ export async function getEntities<Model extends Entity>(
   modelName: string,
   filters: StyledDataTableProps['filtered'] = [],
   page = 1,
-  pageSize = 20,
+  pageSize = 10,
   relationshipsToInclude?: string,
   sort = 'id',
 ) {


### PR DESCRIPTION
Empty rows are no longer displayed.
Notification about no rows found is now presented as a toaster.