### PR TITLE
[packager] Fix packaging errors

### DIFF
--- a/Packager/Packager.cs
+++ b/Packager/Packager.cs
@@ -623,7 +623,7 @@ public class Packager : IPackager
             {
                 resolved = image.AssemblyResolver.Resolve(ar, rp);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Console.WriteLine(ex.Message, ex.InnerException);
             }
@@ -692,7 +692,8 @@ public class Packager : IPackager
 
                 break;
             default:
-                File.Copy(sourceFileName, destFileName, true);
+                if (!File.Exists(destFileName))
+                    File.Copy(sourceFileName, destFileName);
                 break;
         }
     }


### PR DESCRIPTION
Packager searches for required assemblies in `mono-wasm-sdk` directories and in `task-definitions` directories. In some cases assemblies were found in both directories and `File.Copy` was unable to copy file, because it already existed in destination folder.