### PR TITLE
[general] update nginx maximum body size

### DIFF
--- a/nginx.dev.conf
+++ b/nginx.dev.conf
@@ -6,6 +6,7 @@ events {
 
 http {
   server {
+    client_max_body_size 8M;
     listen 80;
 
     location /api {

--- a/nginx.prod.conf
+++ b/nginx.prod.conf
@@ -6,6 +6,7 @@ events {
 
 http {
   server {
+    client_max_body_size 8M;
     listen 80;
 
     location /api {


### PR DESCRIPTION
`nginx` was rejecting requests with body size greater than 1MB. We surely need more than that, my suggestion is to use 8MB as  `client_max_body_size`.