### PR TITLE
Break words in distributed task details page

### DIFF
--- a/frontend/src/features/distributed-tasks/details/get-details-grid.tsx
+++ b/frontend/src/features/distributed-tasks/details/get-details-grid.tsx
@@ -90,7 +90,9 @@ export const DetailsGrid: StatelessComponent<DetailsGridProps> = ({
           <Pane>
             <Text>
               {details.errors.map((error, index) => (
-                <Alert title={error} key={index} intent="danger" />
+                <Alert key={index} intent="danger">
+                  <Text wordBreak="break-all">{error}</Text>
+                </Alert>
               ))}
             </Text>
           </Pane>


### PR DESCRIPTION
This change is required in order to present errors without scrollbar.