### PR TITLE
[frontend] filter tasks in distributed task definition details table

### DIFF
--- a/frontend/src/features/distributed-task-definitions/details/details.tsx
+++ b/frontend/src/features/distributed-task-definitions/details/details.tsx
@@ -140,12 +140,18 @@ export class PureDistributedTaskDefinitionDetails extends PureComponent<
 
   private renderDistributedTasksTable = (): ReactNode => {
     const { tableData } = this.props;
+    const { id } = this.props;
 
     if (!tableData) {
       return null;
     }
 
-    return <DistributedTasksTable {...tableData} />;
+    return (
+      <DistributedTasksTable
+        {...tableData}
+        bindDistributedTaskDefinitionId={id}
+      />
+    );
   };
 
   private renderErrors = (): ReactNode => {

--- a/frontend/src/features/distributed-tasks/table/table.tsx
+++ b/frontend/src/features/distributed-tasks/table/table.tsx
@@ -202,7 +202,7 @@ export class PureDistributedTasksTable extends Component<
     page,
   }) => {
     const { filteringEnabled } = this.state;
-    const { kitsu } = this.props;
+    const { kitsu, bindDistributedTaskDefinitionId } = this.props;
     this.setState({ loading: true, dataFetchingError: undefined });
 
     if (!filteringEnabled) {
@@ -210,6 +210,13 @@ export class PureDistributedTasksTable extends Component<
     }
 
     filtered = this.removeInvalidFilters(filtered);
+
+    if (bindDistributedTaskDefinitionId) {
+      filtered.push({
+        id: 'distributed-task-definition-id',
+        value: bindDistributedTaskDefinitionId,
+      });
+    }
 
     return getEntities<DistributedTaskWithDefinition>(
       kitsu,


### PR DESCRIPTION
Distributed tasks in distributed task definition table were not filtered when refresh button was pressed.