### PR TITLE
Update file name to .bash_profile in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ your PC).
 - Install latest [mono](https://www.mono-project.com/docs/getting-started/install/).
 - Set an enviroment variable with the path to the `mono` compiler
   - `export FrameworkPathOverride=/usr/lib/mono/4.5/`
-  - it is recommended to add the line above to `~/.bashrc`
+  - it is recommended to persist this environment variable in the system (e.g. add it to
+    `~/.bash_profile` on Ubuntu or the equivalent on other operating systems)
 
 ### Post-installation steps
 


### PR DESCRIPTION
`.bash_profile` is the correct place for setting environment variables, not `.bashrc`.

See the discussion at https://github.com/proszewskip/distributed-computing-webworker/commit/b20d5a8cebe63f7e1c8cbe1205a98c781b150ca5#r31837196 for more information.