### PR TITLE
Enable gzip compression in production

### DIFF
--- a/nginx.prod.conf
+++ b/nginx.prod.conf
@@ -9,6 +9,26 @@ http {
     client_max_body_size 8M;
     listen 80;
 
+    # GZIP compression
+    gzip on;
+    gzip_disable "msie6";
+
+    gzip_comp_level 6;
+    gzip_min_length 1100;
+    gzip_proxied any;
+    gzip_types
+        text/plain
+        text/css
+        text/js
+        text/xml
+        text/javascript
+        application/javascript
+        application/x-javascript
+        application/json
+        application/xml
+        application/rss+xml
+        image/svg+xml;
+
     location /api {
       # API server
       rewrite /api/(.*) /$1 break;


### PR DESCRIPTION
Main site size:

* without gzip compression: 992 KB
* with gzip compression: 288 KB

The gzip settings were inspired by https://stackoverflow.com/a/12644530