### PR TITLE
Fix redirecting to the login page

### DIFF
--- a/frontend/src/product-specific/authentication/forward-cookies.ts
+++ b/frontend/src/product-specific/authentication/forward-cookies.ts
@@ -15,5 +15,7 @@ export const forwardCookies = (
     return;
   }
 
-  headers.cookie = req.headers.cookie as string;
+  if (req.headers.cookie) {
+    headers.cookie = req.headers.cookie as string;
+  }
 };


### PR DESCRIPTION
It turns out that when the browser did not send any cookies, forwarding the cookies in next.js failed immediately and that caused a **truly** _unexpected_ error 😄 

Now the cookies are forwarded only if they are present in the initial request