### PR TITLE
Update distributed node timeouts

### DIFF
--- a/frontend/src/features/worker/components/pages-by-status/running-page.tsx
+++ b/frontend/src/features/worker/components/pages-by-status/running-page.tsx
@@ -89,10 +89,7 @@ const RunningStateInfo: StatelessComponent<
             <Text>Waiting...</Text>
           </Status>
 
-          <Text>
-            There are no pending tasks in the system. The worker will retry to
-            ask for a task in a while.
-          </Text>
+          <Text>The worker will try to ask for a task in a while.</Text>
         </>
       );
   }


### PR DESCRIPTION
I have split the timeout before asking for a new task on the distributed node into 2 timeouts:
* `START_NEW_TASK_INTERVAL` - between starting one task and asking for another (currently 200 ms)
* `CHECK_FOR_TASKS_DELAY` - when there have not been any tasks previously (currently 5 seconds)

I have also updated the UI not to show fake information