### PR TITLE
Update EntityFrameworkCore version

### DIFF
--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="JsonApiDotnetCore" Version="2.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.0" />
     <PackageReference Include="NSwag.AspNetCore" Version="12.0.10" />
     <PackageReference Include="NSwag.MSBuild" Version="12.0.10">


### PR DESCRIPTION
Build of backend was failing due to old version of `EntityFrameworkCore`

```
/app/Server/Server.csproj : error NU1605: Detected package downgrade: Microsoft.EntityFrameworkCore.Design from 2.2.1 to 2.2.0. Reference the package directly from the project to select a different version.
/app/Server/Server.csproj : error NU1605:  Server -> Microsoft.AspNetCore.App 2.2.1 -> Microsoft.EntityFrameworkCore.Design (>= 2.2.1 && < 2.3.0)
/app/Server/Server.csproj : error NU1605:  Server -> Microsoft.EntityFrameworkCore.Design (>= 2.2.0)
```