### PR TITLE
Remove packages version reference

### DIFF
--- a/Server.Tests/Server.Tests.csproj
+++ b/Server.Tests/Server.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="JsonApiDotnetCore" Version="2.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.1"/>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.0" />
     <PackageReference Include="NSwag.AspNetCore" Version="12.0.10" />


### PR DESCRIPTION
Reverts #150 

According to https://docs.microsoft.com/en-gb/dotnet/core/tools/csproj#implicit-package-references `AspNetCore.App` should never have an explicit reference.