### PR TITLE
Allow building the project in development

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:10
 
 WORKDIR /app
+ENV INSIDE_CONTAINER=1
 
 # Install dependencies
 COPY ./package.json ./package.json

--- a/frontend/src/product-specific/config.ts
+++ b/frontend/src/product-specific/config.ts
@@ -8,7 +8,7 @@ export const config = {
   /**
    * Server URL when the app runs in production (as a Docker container)
    */
-  productionServerUrl: 'http://backend:5000',
+  containerServerUrl: 'http://backend:5000',
 
   loginPageUrl: '/authentication/login',
 };

--- a/frontend/src/product-specific/server-url-provider/server-url-provider.ts
+++ b/frontend/src/product-specific/server-url-provider/server-url-provider.ts
@@ -24,8 +24,8 @@ export const serverUrlProvider = (req?: IncomingMessage) => {
 };
 
 const getServersideServerUrl = (req: IncomingMessage) => {
-  if (process.env.NODE_ENV === 'production') {
-    return config.productionServerUrl;
+  if (process.env.INSIDE_CONTAINER) {
+    return config.containerServerUrl;
   }
 
   /**


### PR DESCRIPTION
`npm run build` and `npm run start` can be run on the host machine in the development environment.

Previously they were only allowed inside Docker due to how the requests were made.

Now, the `INSIDE_CONTAINER` environment variable is used to determine whether the project is running inside Docker and should use another URL for the server, or not.